### PR TITLE
Move @bufbuild/protobuf from peerDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,8 @@
     "prepack": "pnpm run build",
     "type-check": "tsc --noEmit"
   },
-  "peerDependencies": {
-    "@bufbuild/protobuf": ">=2, <3"
-  },
   "dependencies": {
+    "@bufbuild/protobuf": "^2.8.0",
     "@connectrpc/connect": "^2.1.0",
     "@connectrpc/connect-node": "^2.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@bufbuild/protobuf':
+        specifier: ^2.8.0
+        version: 2.8.0
       '@connectrpc/connect':
         specifier: ^2.1.0
         version: 2.1.0(@bufbuild/protobuf@2.8.0)
@@ -15,9 +18,6 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0(@bufbuild/protobuf@2.8.0)(@connectrpc/connect@2.1.0(@bufbuild/protobuf@2.8.0))
     devDependencies:
-      '@bufbuild/protobuf':
-        specifier: ^2.8.0
-        version: 2.8.0
       '@bufbuild/protoc-gen-es':
         specifier: ^2.8.0
         version: 2.8.0(@bufbuild/protobuf@2.8.0)


### PR DESCRIPTION
## Summary

- Moves `@bufbuild/protobuf` from `peerDependencies` to `dependencies` so it is automatically installed for consumers
- The SDK imports from `@bufbuild/protobuf/codegenv2` and `@bufbuild/protobuf/wkt` at runtime (14 `require()` calls), so it must be present
- With pnpm (which does not auto-install peer deps), importing `@depot/sdk-node` fails with `Cannot find module '@bufbuild/protobuf/wkt'` unless the consumer explicitly adds it

Reported by a customer via support (thread `th_01KJP2QA793HH0199V9CYQ0X29`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)